### PR TITLE
Avoid classloading client-only classes on dedicated servers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loader_version=0.17.2
 loom_version=1.11-SNAPSHOT
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=io.github.jason13official.telecir
 archives_base_name=telecir
 

--- a/src/main/java/io/github/jason13official/telecir/Constants.java
+++ b/src/main/java/io/github/jason13official/telecir/Constants.java
@@ -1,7 +1,5 @@
 package io.github.jason13official.telecir;
 
-import net.minecraft.client.model.geom.ModelLayerLocation;
-import net.minecraft.resources.ResourceLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,18 +8,6 @@ public class Constants {
   public static final String MOD_ID = "telecir";
   public static final String MOD_NAME = "Teleport Circles";
   public static final Logger LOG = LoggerFactory.getLogger(MOD_NAME);
-
-  public static final ModelLayerLocation CIRCLE_MODEL_LAYER = new ModelLayerLocation(
-      TeleCir.identifier("circle"), "main");
-
-  public static final ResourceLocation CIRCLE_DEBUG_TEXTURE = TeleCir.identifier(
-      "textures/entity/debug.png");
-
-  public static final ResourceLocation CIRCLE_INACTIVE_TEXTURE = TeleCir.identifier(
-      "textures/entity/small_circle.png");
-
-  public static final ResourceLocation CIRCLE_ACTIVE_TEXTURE = TeleCir.identifier(
-      "textures/entity/circle.png");
 
   @SuppressWarnings("all")
   public static void debug(String message, Object obj1, Object obj2) {

--- a/src/main/java/io/github/jason13official/telecir/ConstantsClient.java
+++ b/src/main/java/io/github/jason13official/telecir/ConstantsClient.java
@@ -1,0 +1,19 @@
+package io.github.jason13official.telecir;
+
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.resources.ResourceLocation;
+
+public class ConstantsClient {
+
+  public static final ModelLayerLocation CIRCLE_MODEL_LAYER = new ModelLayerLocation(
+      TeleCir.identifier("circle"), "main");
+
+  public static final ResourceLocation CIRCLE_DEBUG_TEXTURE = TeleCir.identifier(
+      "textures/entity/debug.png");
+
+  public static final ResourceLocation CIRCLE_INACTIVE_TEXTURE = TeleCir.identifier(
+      "textures/entity/small_circle.png");
+
+  public static final ResourceLocation CIRCLE_ACTIVE_TEXTURE = TeleCir.identifier(
+      "textures/entity/circle.png");
+}

--- a/src/main/java/io/github/jason13official/telecir/TeleCirClient.java
+++ b/src/main/java/io/github/jason13official/telecir/TeleCirClient.java
@@ -26,7 +26,7 @@ public class TeleCirClient implements ClientModInitializer {
 
     EntityRendererRegistry.register(ModEntities.CIRCLE, CircleRenderer::new);
 
-    EntityModelLayerRegistry.registerModelLayer(Constants.CIRCLE_MODEL_LAYER,
+    EntityModelLayerRegistry.registerModelLayer(ConstantsClient.CIRCLE_MODEL_LAYER,
         CircleModel::createBodyLayer);
 
     ParticleFactoryRegistry.getInstance()

--- a/src/main/java/io/github/jason13official/telecir/impl/client/renderer/CircleRenderer.java
+++ b/src/main/java/io/github/jason13official/telecir/impl/client/renderer/CircleRenderer.java
@@ -3,7 +3,7 @@ package io.github.jason13official.telecir.impl.client.renderer;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
-import io.github.jason13official.telecir.Constants;
+import io.github.jason13official.telecir.ConstantsClient;
 import io.github.jason13official.telecir.TeleCir;
 import io.github.jason13official.telecir.impl.client.model.CircleModel;
 import io.github.jason13official.telecir.impl.common.world.entity.TeleportCircle;
@@ -29,13 +29,13 @@ public class CircleRenderer extends EntityRenderer<TeleportCircle> {
 
   public CircleRenderer(Context context) {
     super(context);
-    this.model = new CircleModel(context.bakeLayer(Constants.CIRCLE_MODEL_LAYER));
+    this.model = new CircleModel(context.bakeLayer(ConstantsClient.CIRCLE_MODEL_LAYER));
   }
 
   @Override
   public ResourceLocation getTextureLocation(TeleportCircle circle) {
-    return TeleCir.DEBUG ? Constants.CIRCLE_DEBUG_TEXTURE
-        : circle.activated() ? Constants.CIRCLE_ACTIVE_TEXTURE : Constants.CIRCLE_INACTIVE_TEXTURE;
+    return TeleCir.DEBUG ? ConstantsClient.CIRCLE_DEBUG_TEXTURE
+        : circle.activated() ? ConstantsClient.CIRCLE_ACTIVE_TEXTURE : ConstantsClient.CIRCLE_INACTIVE_TEXTURE;
   }
 
   @Override

--- a/src/main/java/io/github/jason13official/telecir/impl/common/world/entity/TeleportCircle.java
+++ b/src/main/java/io/github/jason13official/telecir/impl/common/world/entity/TeleportCircle.java
@@ -8,6 +8,8 @@ import io.github.jason13official.telecir.impl.common.registry.ModParticles;
 import io.github.jason13official.telecir.impl.common.util.RotationHelper;
 import io.github.jason13official.telecir.impl.server.data.CircleRecord;
 import io.netty.util.Constant;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -117,8 +119,7 @@ public class TeleportCircle extends AbstractTeleportCircle {
     } else {
 
       if (this.activated()) {
-        Minecraft.getInstance()
-            .setScreen(new LocationTeleportScreen(this.getUUID(), this.getName().getString()));
+        this.openLocationTeleportScreen();
       }
 
       return InteractionResult.SUCCESS;
@@ -191,5 +192,11 @@ public class TeleportCircle extends AbstractTeleportCircle {
         }
       }
     }
+  }
+
+  @Environment(EnvType.CLIENT)
+  private void openLocationTeleportScreen() {
+      Minecraft.getInstance()
+              .setScreen(new LocationTeleportScreen(this.getUUID(), this.getName().getString()));
   }
 }


### PR DESCRIPTION
- Split client-only constants in `Constants` into a separate `ConstantsClient` class to avoid classloading `ModelLayerLocation` on the wrong side
- Add separate method for opening the teleport circle screen, annotated with `@Environment(EnvType.CLIENT)`, to avoid classloading `Screen` on the wrong side (fixes a crash during startup on dedicated servers)